### PR TITLE
Add python control scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@ This project simulates the Motoman SIA10F robotic arm using the MoveIt! package 
     ```
 
 #### Usage
-
-##### Launching the Simulation in Gazebo
-- **Start an empty Gazebo world:**
-    ```bash
-    roslaunch sia10f_gazebo empty_world.launch
-    ```
 - **Run the main simulation launch file:**
     ```bash
     roslaunch sia10f_gazebo main.launch

--- a/README.md
+++ b/README.md
@@ -1,74 +1,81 @@
-# Motoman SIA10F Simulation with MoveIt!
+### Motoman SIA10F Simulation with MoveIt!
 
-## Project Description
-This project focuses on simulating the Motoman SIA10F robotic arm using the MoveIt! package in ROS1. It serves as a basic tutorial for creating URDF files, building MoveIt packages, and performing motion planning through Python. The goal is to understand and implement robotic arm functionalities and provide a documented workflow for others to follow.
+#### Project Description
+This project simulates the Motoman SIA10F robotic arm using the MoveIt! package in ROS1. It provides a step-by-step approach to creating URDF files, configuring MoveIt packages, and performing motion planning with Python. This resource aims to help developers understand and implement robotic arm functionalities in a Gazebo simulation.
 
-## Key Features
-- Creation of a URDF file for the Motoman SIA10F robot arm.
-- Integration with the MoveIt! package for motion planning.
-- Visualization of the robot model in RViz.
-- Configurable RViz settings for better visualization and debugging.
+#### Key Features
+- **URDF model of the Motoman SIA10F robot arm.**
+- **MoveIt! integration for motion planning and execution.**
+- **RViz visualization with configurable settings.**
+- **Python scripts for planning and controlling the arm:** Added scripts for commanding the robotic arm directly via Python.
 
-## Installation Instructions
+#### Installation Instructions
 
-### Prerequisites
-- **ROS**: Ensure you have ROS Noetic installed on your system.
-- **Catkin**: Make sure your ROS environment is set up with a Catkin workspace.
+##### Prerequisites
+- **ROS Noetic:** Ensure it’s installed and configured with a Catkin workspace.
 
-### Setup Steps
-1. Clone this repository into your ROS workspace:
-   ```bash
-   cd ~/ros_ws/src
-   git clone https://github.com/smtbhd32/sia10f-urdf-moveit-motion-planning/
-   ```
+##### Setup
+1. **Clone the repository into your Catkin workspace:**
+    ```bash
+    cd ~/ros_ws/src
+    git clone https://github.com/smtbhd32/sia10f-urdf-moveit-motion-planning.git
+    ```
 
-2. **Pull the latest changes** (if needed):
-   ```bash
-   cd sia10f-urdf-moveit-motion-planning
-   git pull
-   cd ..
-   ```
+2. **Install Dependencies:** Use `rosdep` to install all dependencies listed in the `package.xml`:
+    ```bash
+    cd ~/ros_ws
+    rosdep install --from-paths src --ignore-src -r -y
+    ```
 
-3. Install all required packages and dependencies defined in the `rosdep` file:
-   ```bash
-   rosdep install --from-paths src --ignore-src -r -y
-   ```
+3. **Build the Workspace:**
+    ```bash
+    catkin_make
+    ```
 
-4. Build your workspace:
-   ```bash
-   cd ~/ros_ws
-   catkin_make
-   ```
+4. **Source the Workspace:**
+    ```bash
+    source devel/setup.bash
+    ```
 
-5. Source the workspace:
-   ```bash
-   source devel/setup.bash
-   ```
+#### Usage
 
-## Usage
+##### Launching the Simulation in Gazebo
+- **Start an empty Gazebo world:**
+    ```bash
+    roslaunch sia10f_gazebo empty_world.launch
+    ```
+- **Run the main simulation launch file:**
+    ```bash
+    roslaunch sia10f_gazebo main.launch
+    ```
 
-### Launching the Robot Simulation
-To launch the Gazebo simulation, use the following command:
-```bash
-roslaunch sia10f_gazebo main.launch
-```
+##### Running MoveIt for Motion Planning
+- **To control the robot arm with MoveIt and RViz:**
+    ```bash
+    roslaunch my_robot_moveit_config my_robot_planning_execution.launch
+    ```
 
-### Running MoveIt! for Planning and Execution
-To control the robot using MoveIt!, launch the following command:
-```bash
-roslaunch my_robot_moveit_config my_robot_planning_execution.launch
-```
+##### Running Python Control Scripts
+The `scripts` folder contains Python scripts for commanding the robot arm through MoveIt.
 
-### Example Commands
-- View the Robot in RViz: Ensure that you have RViz installed, and launch the robot as specified above.
+1. **Navigate to the scripts folder:**
+    ```bash
+    cd ~/ros_ws/src/sia10f_robot/my_robot_moveit_config/scripts
+    ```
 
-## Documentation
-For additional resources and detailed explanations of the code, refer to the comments in the codebase and the configuration files.
+2. **Run the example script:**
+    ```bash
+    rosrun my_robot_moveit_config moveit_joint_control_example.py
+    ```
+    This script sets joint values for the "manipulator" group and executes the plan.
 
-## Acknowledgements
-This project is based on the tutorial by The Construct (https://www.youtube.com/watch?v=J6Mu1P6FlxY). Special thanks for the valuable guidance in understanding ROS and robot simulation.
+#### Folder Structure
+- **sia10f_control:** Control configurations and launch files.
+- **sia10f_description:** URDF and Xacro files defining the robot’s model.
+- **sia10f_gazebo:** Gazebo simulation files.
+- **my_robot_moveit_config:** MoveIt! configurations for the SIA10F robot.
+- **scripts:** Contains Python scripts for planning and executing commands via MoveIt.
 
-## License
-This project is licensed under the MIT License. See the LICENSE file for more details.
-
+#### Acknowledgements
+This project builds upon tutorials by The Construct and resources from other contributors.
 ---

--- a/file_structure.txt
+++ b/file_structure.txt
@@ -61,7 +61,10 @@
 │   │   ├── trajectory_execution.launch.xml
 │   │   ├── warehouse.launch
 │   │   └── warehouse_settings.launch.xml
-│   └── package.xml
+│   ├── package.xml
+│   └── scripts
+│       ├── moveit_example.py
+│       └── moveit_joint_control_example.py
 ├── osrf-common
 │   ├── CMakeLists.txt
 │   └── osrf_msgs
@@ -126,4 +129,4 @@
         └── worlds
             └── sia10f.world
 
-32 directories, 94 files
+33 directories, 96 files

--- a/my_robot_moveit_config/scripts/moveit_example.py
+++ b/my_robot_moveit_config/scripts/moveit_example.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import sys
+import copy
+import rospy
+import moveit_commander
+import moveit_msgs.msg
+import geometry_msgs.msg
+
+# Initialize moveit_commander and rospy
+moveit_commander.roscpp_initialize(sys.argv)
+rospy.init_node('move_group_python_interface_tutorial', anonymous=True)
+
+# Instantiate a RobotCommander, PlanningSceneInterface, and MoveGroupCommander
+robot = moveit_commander.RobotCommander()
+scene = moveit_commander.PlanningSceneInterface()
+group = moveit_commander.MoveGroupCommander("manipulator")
+
+# Create a publisher for visualizing the planned path in Rviz
+display_trajectory_publisher = rospy.Publisher('/move_group/display_planned_path', moveit_msgs.msg.DisplayTrajectory, queue_size=10)
+
+# Define the pose target
+pose_target = geometry_msgs.msg.Pose()
+pose_target.orientation.w = 1.0
+pose_target.position.x = 0.3
+pose_target.position.y = 0.0
+pose_target.position.z = 1.1
+
+# Set the target pose for the MoveGroupCommander
+group.set_pose_target(pose_target)
+
+# Plan the motion to the target pose
+plan = group.plan()
+
+# Executing the plan in simulation
+group.go(wait=True)
+
+# Allow some time for the planning process to finish
+rospy.sleep(5)
+
+# Shut down moveit_commander
+moveit_commander.roscpp_shutdown()

--- a/my_robot_moveit_config/scripts/moveit_joint_control_example.py
+++ b/my_robot_moveit_config/scripts/moveit_joint_control_example.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import sys
+import copy
+import rospy
+import moveit_commander
+import moveit_msgs.msg
+import geometry_msgs.msg
+
+# Initialize the moveit_commander and rospy node
+moveit_commander.roscpp_initialize(sys.argv)
+rospy.init_node('move_group_python_interface_tutorial', anonymous=True)
+
+# Instantiate RobotCommander (interface to the robot), PlanningSceneInterface (environment), and MoveGroupCommander (controls a planning group)
+robot = moveit_commander.RobotCommander()
+scene = moveit_commander.PlanningSceneInterface()
+group = moveit_commander.MoveGroupCommander("manipulator")
+
+# Create a DisplayTrajectory publisher, which publishes display trajectories to RViz
+display_trajectory_publisher = rospy.Publisher('/move_group/display_planned_path', moveit_msgs.msg.DisplayTrajectory, queue_size=20)
+
+# Get the current joint values and modify them for the new target
+group_variable_values = group.get_current_joint_values()
+group_variable_values[3] = 1.5
+group.set_joint_value_target(group_variable_values)
+
+# Plan to the joint-space goal and execute the plan
+plan2 = group.plan()
+group.go(wait=True)
+
+# Give some time for the plan to execute
+rospy.sleep(5)
+
+# Shutdown the moveit_commander
+moveit_commander.roscpp_shutdown()


### PR DESCRIPTION
Add Python scripts for planning and executing arm commands"
- Created a `scripts` directory under `my_robot_moveit_config` to house Python scripts for controlling the SIA10F robotic arm.
- Added an example Python script (`moveit_joint_control_example.py`) that uses MoveIt! to set joint values and execute planned trajectories.
- This script initializes MoveIt! with a "manipulator" group, publishes planned paths, and allows setting joint targets directly.
- The script is fully executable and provides a foundation for more advanced control commands.